### PR TITLE
improve regex and end of list text

### DIFF
--- a/NaLaPla/Program.cs
+++ b/NaLaPla/Program.cs
@@ -116,7 +116,7 @@
                 //var prompt = $"Please specify one or two steps that needs to be done to {plan.description} when you {basePlan.description}";
                 var prompt = $"Your task is to {basePlan.description}. Repeat the list and add {ExpandSubtaskCount} subtasks to each of the items.\n\n";
                 prompt += Util.GetNumberedSteps(plan);
-                prompt += "END";
+                prompt += "END LIST";
                 Console.WriteLine(prompt);
                 return prompt;
             }
@@ -128,7 +128,7 @@
                 */
                 var prompt = $"Below is part of a plan to {basePlan.description}. Repeat the list and add {ExpandSubtaskCount} subtasks to each of the items\n\n";
                 prompt += Util.GetNumberedSteps(plan);
-                prompt += "END";
+                prompt += "END LIST";
                 Console.WriteLine(prompt);
                 return prompt;
             }

--- a/NaLaPla/Task.cs
+++ b/NaLaPla/Task.cs
@@ -3,10 +3,8 @@ namespace NaLaPla
 public class Task {
         public string? description;
         public int planLevel;    
-
         public List<string> subTaskDescriptions = new List<string>();    
         public List<Task> subTasks = new List<Task>();
-
         public Task? parent;
     }
 }

--- a/NaLaPla/Util.cs
+++ b/NaLaPla/Util.cs
@@ -50,11 +50,12 @@ namespace NaLaPla
             }
         }
 
-        // Replace numbered sub bullets (i.e. "2.1", "3.2.1", " 2." with "-" marks)
+        // Replace numbered sub bullets (i.e. "2.1", "3.2.1", " 2.", " a." with "-" marks)
         private static string NumberToBullet(string text) {
-            var bulletText = Regex.Replace(text, @"\d.\d.", "-");
-            bulletText = Regex.Replace(bulletText, @"\d.\d", "-");
-            return Regex.Replace(bulletText, @" \d.", "-");
+            var bulletText = Regex.Replace(text, @"\d\.\d.", "-");
+            bulletText = Regex.Replace(bulletText, @"\d\.\d", "-");
+            bulletText = Regex.Replace(bulletText, @" \d\.", "-");
+            return Regex.Replace(bulletText, @" [a-zA-Z]\.", "-");
         }
 
         public static void UpdatePlan(Task plan, string gptResponse) {


### PR DESCRIPTION
This fixes when GPT returns list with bullets marked as  "a.", "b.", "c." and gives a stronger prompt for end of list