### PR TITLE
Typos in WritePlan definition

### DIFF
--- a/NaLaPla/Util.cs
+++ b/NaLaPla/Util.cs
@@ -161,7 +161,7 @@ namespace NaLaPla
             UpdatePlan(plan2, parse2);
         }
 
-        public static void WritePlan(Task plan  StreamWriter writer = null {
+        public static void WritePlan(Task plan, StreamWriter writer = null) {
             var planText = PlanToString(plan);
             Util.WriteToConsole(planText, ConsoleColor.White);
 


### PR DESCRIPTION
Somehow lost a comma and a parenthesis, and c# is touchy about that.