### PR TITLE
grounding on full dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,5 @@ bin/
 obj/
 output/
 index/
-wiki_samples/
-wiki_full/
-NaLaPla/Unconfirmed 956238.crdownload
+GroundingData/
 *.zip

--- a/NaLaPla/IR.cs
+++ b/NaLaPla/IR.cs
@@ -34,12 +34,15 @@ namespace NaLaPla
 
             try
             {
+                var numberDocuments = 0;
                 var doc = dataProvider.GetNextDocument();
                 while (doc != null) 
                 {
+                    numberDocuments++;
                     writer.AddDocument(doc);
                     doc = dataProvider.GetNextDocument();
                 }
+                Util.WriteToConsole($"Added {numberDocuments} documents.", ConsoleColor.Green);
                 writer.Flush(triggerMerge: false, applyAllDeletes: false);
             }
             catch
@@ -54,7 +57,7 @@ namespace NaLaPla
             }
         }
 
-        public static List<string> GetRelatedDocuments(string text, int maxResults = 5) 
+        public static List<string> GetRelatedDocuments(string text, bool showGrounding = false, int maxResults = 20) 
         {
             using var dir = FSDirectory.Open(IndexDirectory());
             using var analyzer = new StandardAnalyzer(AppLuceneVersion);
@@ -70,12 +73,13 @@ namespace NaLaPla
             var hits = searcher.Search(query, maxResults).ScoreDocs;
 
             // Display the output in a table
-            //Util.WriteToConsole(text, ConsoleColor.Blue);
-            Util.WriteToConsole($"{"Score",10}" + $" {"Topic",-15}", ConsoleColor.DarkBlue);
-            foreach (var hit in hits)
-            {
-                var foundDoc = searcher.Doc(hit.Doc);
-                Util.WriteToConsole($"{hit.Score:f8}" + $" {foundDoc.Get("topic"),-15}", ConsoleColor.DarkCyan);
+            if (showGrounding) {
+                Util.WriteToConsole($"{"Score",10}" + $" {"Topic",-15}", ConsoleColor.DarkBlue);
+                foreach (var hit in hits)
+                {
+                    var foundDoc = searcher.Doc(hit.Doc);
+                    Util.WriteToConsole($"{hit.Score:f8}" + $" {foundDoc.Get("topic"),-30}", ConsoleColor.DarkCyan);
+                }
             }
 
             var topDocuments = hits.Select(hit => searcher.Doc(hit.Doc).Get("body")).ToList();

--- a/NaLaPla/Minecraft/MineCraftDataProvider.cs
+++ b/NaLaPla/Minecraft/MineCraftDataProvider.cs
@@ -10,7 +10,10 @@ namespace NaLaPla
     
         private string MinecraftDataFolder = "";
 
+        // Number of words to require before adding section to index
         const int MIN_REQUIRED_WORDS = 5;
+
+        const string SOURCE_DIR = "GroundingData";
 
         // Stack of files to process
         private Stack<string> _DataFiles = null;
@@ -22,27 +25,42 @@ namespace NaLaPla
         private WikiRecord CurWikiRecord = null;
     
 
+        private string DataPath {
+            get {
+                return Path.Combine(Environment.CurrentDirectory, SOURCE_DIR, MinecraftDataFolder);
+            }
+        }
+
         public MineCraftDataProvider(string minecraftDataFolder) {
             this.MinecraftDataFolder = minecraftDataFolder;
 
-            var path = Path.Combine(Environment.CurrentDirectory, MinecraftDataFolder);
-            if(!System.IO.Directory.Exists(path)) {
-                throw new Exception($"Directory Not FoundL {path}");
+            if(!System.IO.Directory.Exists(DataPath)) {
+                throw new Exception($"Directory Not Found {DataPath}");
             }
+        }
+
+        // Utility that removes image directories from the wiki dataset as they aren't needed
+        private void CleanFiles() {
+            var dirNames = new Stack<string>(System.IO.Directory.GetDirectories(DataPath, "images", SearchOption.AllDirectories));
+            foreach (var dirName in dirNames) {
+                System.IO.Directory.Delete(dirName, true);
+                Util.WriteToConsole($"Deleting: {dirName}", ConsoleColor.DarkGreen);
+
+            }
+            Util.WriteToConsole($"Deleted {dirNames.Count} directories", ConsoleColor.Green );
         }
 
         private Stack<string> DataFiles {
             get {
                 if (_DataFiles == null) {
-                    var path = Path.Combine(Environment.CurrentDirectory, MinecraftDataFolder);
-                    _DataFiles = new Stack<string>(System.IO.Directory.GetFiles(path, "data.json", SearchOption.AllDirectories));
+                    _DataFiles = new Stack<string>(System.IO.Directory.GetFiles(DataPath, "data.json", SearchOption.AllDirectories));
                     Util.WriteToConsole($"{_DataFiles.Count()} Documents Found", ConsoleColor.Green);
                 }
                 return _DataFiles;
             }
         }
 
-        // Get next document section.  If all sections have been handles, move on to next file
+        // Get next document section.  If all sections have been handled, move on to next file
         private string NextDocumentSection() {
             if (SubSections.Count == 0) {
                 if (DataFiles.Count == 0) {
@@ -51,23 +69,114 @@ namespace NaLaPla
                 var nextFile = DataFiles.Pop();
                 var jsonString = File.ReadAllText(nextFile);
                 CurWikiRecord = Newtonsoft.Json.JsonConvert.DeserializeObject<WikiRecord>(jsonString);
+
+                if (CurWikiRecord == null || CurWikiRecord.texts == null) {
+                    return NextDocumentSection();    
+                }
                 var subTexts = CurWikiRecord.texts.Select(t => t.text);
-                SubSections = GetValidDocuments(subTexts);
-                Util.WriteToConsole($"Adding: {CurWikiRecord.Title, -30} ({DataFiles.Count()} remaining)", ConsoleColor.DarkGreen);
-            }
+                SubSections = GenerateDocumentSections(CurWikiRecord.texts);
+                Util.WriteToConsole($"Adding: {CurWikiRecord.Title, -30} with {SubSections.Count, -10} items ({DataFiles.Count()} remaining)", ConsoleColor.DarkGreen);
+                return NextDocumentSection();
+            } 
             var nextDocument = SubSections.Pop();    
             return nextDocument;
         }
 
+        // Add text to stack but only if meets length requirements
+        private void AddText(Text curText, Stack<string> outputStack) {
+            var curTextNumWords = Util.NumWordsIn(curText.text);
+            if (curTextNumWords >= MIN_REQUIRED_WORDS) {
+                outputStack.Push(curText.text);
+            }
+        }
+
+        // Based on position is the next text item indented from the previous
+        private bool IsSubItem(Text curText, Text nextText) {
+            var inset = nextText.LeftMargin - curText.LeftMargin;
+            if (inset < 40 && inset > 15) {
+                return true;
+            }
+            return false;
+        }
+
+        // Do the two text items have the same indentation
+        private bool IsPeer(Text curText, Text nextText) {
+            var inset = nextText.LeftMargin - curText.LeftMargin;
+            if (inset == 0) {
+                return true;
+            }
+            return false;
+        }
+
+        private void ProcessText(Text curText, Queue<Text> inputQueue, Stack<string> outputStack, string section) {
+
+            // Get next item, if none add final result
+            Text nextText;
+            if (!inputQueue.TryDequeue(out nextText)) {
+                if (section == "") {
+                    AddText(curText, outputStack);
+                }
+                else {
+                    outputStack.Push(section);
+                }
+                return;
+            }
+
+            // If next item a sub-item of the current ont
+            if (IsSubItem(curText, nextText)) {
+                if (section != "") {
+                    section += $"{nextText.text}\n";
+                }
+                else {
+                    section += $"{curText.text}\n{nextText.text}\n";
+                }
+                // Process the next item
+                ProcessText(nextText, inputQueue, outputStack, section);   
+
+            }
+            // Is next item a peer
+            else if (IsPeer(curText, nextText)) {
+                // If under the same section, add to section and keep processing
+                if (section != "") {
+                    section += $"{nextText.text}\n";
+
+                    // Process the next item
+                    ProcessText(nextText, inputQueue, outputStack, section);    
+                }
+                // Otherwise add section and process next item
+                else {
+                    // Add accumulated section
+                    AddText(curText, outputStack);
+
+                    // Process the next item
+                    ProcessText(nextText, inputQueue, outputStack, "");
+                }
+            }
+            // Next item is not connect to this one
+            else {
+                if (section != "") {
+                    outputStack.Push(section);
+                }
+                else {
+                    // Add the current item
+                    AddText(curText, outputStack);
+                }
+
+                // Process the next item
+                ProcessText(nextText, inputQueue, outputStack, "");
+            }
+
+        }
         // Filter on document section
-        private Stack<string> GetValidDocuments(IEnumerable<string> documents) {
-            var validDocuments = documents.ToList().Where(d => {
-                // Ignore short document sections as they are mostly titles, section headings, etc
-                // TODO: Might be able do something smart here and combine document sections
-                var numWords = Util.NumWordsIn(d);
-                return numWords > MIN_REQUIRED_WORDS;
-            });
-            return new Stack<string>(validDocuments);
+        private Stack<string> GenerateDocumentSections(List<Text> sections) {
+            var outputStack = new Stack<string>();
+            var inputQueue = new Queue<Text>(sections);
+
+            Text nextText;
+            if (inputQueue.TryDequeue(out nextText)) {
+                ProcessText(nextText, inputQueue, outputStack, ""); 
+            }
+            return outputStack;
         }
 
         public Document GetNextDocument() {

--- a/NaLaPla/Minecraft/WikiRecord.cs
+++ b/NaLaPla/Minecraft/WikiRecord.cs
@@ -61,5 +61,12 @@ namespace NaLaPla
     {
         public string text { get; set; }
         public List<double> bbox { get; set; }
+
+        public double LeftMargin 
+        {
+            get {
+                return bbox[0];
+            }
+        }
     }
 }

--- a/NaLaPla/Program.cs
+++ b/NaLaPla/Program.cs
@@ -40,6 +40,8 @@ namespace NaLaPla
 
     class Program {
 
+        const int MAX_PROMPT_SIZE = 2000;
+
         static Plan ?basePlan;
         static int GPTRequestsTotal = 0;
 
@@ -447,11 +449,15 @@ namespace NaLaPla
             
             // Now add grounding 
             if (configuration.useGrounding) {
-                var documents = IR.GetRelatedDocuments($"{description}\n{numberedSubTasksAsString}");
+                var promptSize = Util.NumWordsIn(prompt);
+                var maxGrounds = MAX_PROMPT_SIZE - promptSize;
+
+                var documents = IR.GetRelatedDocuments($"{description}\n{numberedSubTasksAsString}", configuration.showGrounding);
                 var grounding = "";
                 foreach (var document in documents) {
                     grounding += $"{document}{Environment.NewLine}";
                 }
+                grounding = Util.LimitWordCountTo(grounding, maxGrounds);
                 prompt = $"{grounding}{Environment.NewLine}{prompt}";
             }
 
@@ -463,6 +469,5 @@ namespace NaLaPla
             plan.prompt = new Prompt(prompt,configuration);
             return prompt;
         }
-   
     }
-  }
+}

--- a/NaLaPla/RuntimeConfig.cs
+++ b/NaLaPla/RuntimeConfig.cs
@@ -2,8 +2,15 @@ namespace NaLaPla
 {
     public class RuntimeConfig {
         public int maxConcurrentGPTRequests = 25;
-        public bool showPrompts = false; // whether or not to print each prompt as it is submitted to GPT. Prompts always stored in plan.prompt.
-        public bool showResults = false; // print the parsed result of each request to the console
+
+        // whether or not to print each prompt as it is submitted to GPT. Prompts always stored in plan.prompt.
+        public bool showPrompts = false; 
+        
+        // print the parsed result of each request to the console
+        public bool showResults = false; 
+
+        // Show document retrieval when grounding is employed
+        public bool showGrounding = false;
 
         // Should grounding be added to prompts
         public bool useGrounding = true;
@@ -20,7 +27,7 @@ namespace NaLaPla
         public override string ToString() {
             var stringified = $"expandDepth = {expandDepth}, subtaskCount = {subtaskCount},"
             + $" default temperature = {temperature}, temperature multiplier per level = {tempMultPerLevel}, maxConcurrentGPTRequests = {maxConcurrentGPTRequests},"
-            + $" showPrompts = {showPrompts}, showResults = {showResults}, useGrounding = {useGrounding}, shouldLoadPlan = {shouldLoadPlan}, indexToBuild = {indexToBuild}";
+            + $" showPrompts = {showPrompts}, showResults = {showResults}, showGrounding = {showGrounding}, useGrounding = {useGrounding}, shouldLoadPlan = {shouldLoadPlan}, indexToBuild = {indexToBuild}";
             return stringified;
         }
     }

--- a/NaLaPla/Util.cs
+++ b/NaLaPla/Util.cs
@@ -263,5 +263,9 @@ namespace NaLaPla
             }
             return wordCount;
         }
+
+        static public string LimitWordCountTo(string text, int number) {
+             return text.Split(' ').Take(number).Aggregate((a, b) => a + " " + b); 
+        }
     }
 }


### PR DESCRIPTION
- smarter handling of document sub-sections.  Combine sections when detect section header and data below it
- Utility "CleanFiles" for removing image files from minecraft wiki database (takes from 36gb - 20gb)
- new "ShowGrounding" configuration to show search results (false by default)
- add maximum amount of grounded allowed by API