### PR TITLE
augment wiki data

### DIFF
--- a/NaLaPla/Minecraft/WikiRecord.cs
+++ b/NaLaPla/Minecraft/WikiRecord.cs
@@ -26,6 +26,11 @@ namespace NaLaPla
         public string url { get; set; }
         public string title { get; set; }
         public string time { get; set; }
+
+        // Has the data been augmented with HTML info
+        public bool hasBeenAugmented { get; set; } = false;
+
+        public string fileName { get; set; }
     }
 
     public class WikiRecord
@@ -62,6 +67,7 @@ namespace NaLaPla
         public string text { get; set; }
         public List<double> bbox { get; set; }
 
+        public string htmlTag { get; set; }
         public double LeftMargin 
         {
             get {

--- a/NaLaPla/NaLaPla.csproj
+++ b/NaLaPla/NaLaPla.csproj
@@ -8,6 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />


### PR DESCRIPTION
When wiki json file is loaded if it hasn't been augmented yet, it loads the web page and augments the text to include information about the associated HTML tags for that text ("htmlTag").  It then resaves the file.   It takes a little while to run but only needs to be run once.

Not doing anything with augmented data yet but will be employed to create better section consolidation for grounding

        {
            "text": "Micro shelter",
            "bbox": [
                202.046875,
                6753.203125,
                726.0,
                43.0
            ],
            "htmlTag": "h2",
            "LeftMargin": 202.046875
        },